### PR TITLE
Do not automatically load .env variables in script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     ports:
       - 3000:3000
     environment:
+      # Metabase application database configuration
       - MB_DB_TYPE=postgres
       - MB_DB_DBNAME=metabase
       - MB_DB_PORT=5432
@@ -74,6 +75,11 @@ services:
       postgres:
         condition: service_healthy
     restart: "no"
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - EMBULK_POSTGRESQL_USER=cibnav
+      - EMBULK_POSTGRESQL_HOST=postgres
+      - EMBULK_POSTGRESQL_PORT=5432
     entrypoint:
       [
         "bash",

--- a/scripts/setup_postgres_data.sh
+++ b/scripts/setup_postgres_data.sh
@@ -10,8 +10,6 @@ function indent {
 }
 
 
-# Load environment variables
-set -o allexport && . .env && set +o allexport
 export PGPASSWORD="${POSTGRES_PASSWORD}"
 
 USER="${EMBULK_POSTGRESQL_USER}"

--- a/wip.txt
+++ b/wip.txt
@@ -1,16 +1,16 @@
 # WIP
 
-* Gestion des secrets et des accès :  qu'est-ce-qu'il se passe si nous quittons le projet ?
+* Gestion des secrets et des accès :  qu'est-ce-qu'il se passe si nous quittons
+  le projet ?
 * Regarder la mise-à-jour de sitrep avec un connecteur SEAMIS
+* Le déploiement devrait être automatisé, et les bonnes variables
+  d'environnement définis dans cette procédure.
+  * Supprimer le `load_dotenv()` des scripts qui l'utilisent : les variables
+    d'environnements devraient être de la responsabilité de l'appelant.
 
 # Backlog
 
 ## Déploiement
-
-* [ ] Debug écriture des SITREP en base
-  * On pense que c'est au moment de "to_csv" que ça ne fonctionne pas bien dans `airflow tasks test sitrep_web_postgre telechargement_sitrep`
-  * Un test manuel d'écriture avec la même config lancé depuis python a l'air de fonctionner.
-
 
 * [ ] Gérer le déploiemnt avec la DSI
 


### PR DESCRIPTION
Dans ma PR sur les variables d'environnement (#5), j'ai appliqué un anti-pattern : le fichier `.env` est censé définir des variables d'environnement par défaut (même si je n'ai pas trouvé de source qui fait autorité sur comment les utiliser, chacun y va un peu de sa sauce), et non la configuration à être utilisée à tout prix. 

Mon malaise avec le code actuel venait de la difficulté à configurer le même script pour qu'il puisse tourner en local ou dans un docker-compose, notamment du fait de l'export des variables du ".env" à l'intérieur du script. 

Cette PR vise à réparer (partiellement) cette erreur :
- retrait de l'export du variable du ".env" du script "script/setup_postgres_data.sh". C'est la responsabilité de l'appelant (nous, docker-compose) de garantir les bonnes variables d'environnement. 
- Définition des bonnes variables d'environnement dans "docker-compose.yml" pour "postgres-data-setup". Le mot de passe est lu de l'environnement du shell, ou, à défaut, du fichier ".env". 

Ce qui n'est pas réparé : 
- Je n'ai pas touché à `load_dotenv()` dans les scripts python, parce que j'ai peur qu'on se fasse mordre au moment du déploiement : il faudrait un déploiement (semi-)automatisé pour pouvoir garantir le bon environnement au moment du déclenchement des tâches airflow, car si on compte sur l'export manuel du ".env" on va l'oublier une fois sur deux. J'ai mis un point en ce sens dans "wip.txt"